### PR TITLE
 Add an adapter for the net-http-persistent gem

### DIFF
--- a/artemis.gemspec
+++ b/artemis.gemspec
@@ -15,12 +15,13 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject {|f| f.match(%r{^(test)/}) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "activesupport", ">= 4.2.0"
   spec.add_dependency "graphql-client", ">= 0.13.0"
   spec.add_dependency "railties", ">= 4.2.0"
-  spec.add_dependency "activesupport", ">= 4.2.0"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
-  spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "appraisal", "~> 2.2"
+  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "net-http-persistent", "~> 3.0"
+  spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.8"
 end

--- a/lib/artemis/adapters.rb
+++ b/lib/artemis/adapters.rb
@@ -7,8 +7,8 @@ module Artemis
     extend ActiveSupport::Autoload
 
     autoload :NetHttpAdapter
+    autoload :NetHttpPersistentAdapter
     autoload :TestAdapter
-    # autoload :NetHttpPersistentAdapter
 
     class << self
       ##

--- a/spec/unit/adapters/net_http_adapter_spec.rb
+++ b/spec/unit/adapters/net_http_adapter_spec.rb
@@ -1,5 +1,0 @@
-describe Artemis::Adapters::NetHttpAdapter do
-  describe "#execute" do
-    it "makes an actual HTTP request"
-  end
-end

--- a/spec/unit/adapters_spec.rb
+++ b/spec/unit/adapters_spec.rb
@@ -1,0 +1,59 @@
+require 'json'
+require 'rack'
+
+describe 'Adapters' do
+  FakeServer = ->(env) {
+    body = {
+      data: JSON.parse(env['rack.input'].read),
+      errors: [],
+      extensions: {}
+    }.to_json
+
+    [200, {}, [body]]
+  }
+
+  before :all do
+    @server_thread = Thread.new do
+      Rack::Handler::WEBrick.run(FakeServer, Port: 8000, Logger: WEBrick::Log.new('/dev/null'), AccessLog: [])
+    end
+
+    loop do
+      begin
+        TCPSocket.open('localhost', 8000)
+        break
+      rescue Errno::ECONNREFUSED
+        # no-op
+      end
+    end
+  end
+
+  after :all do
+    Rack::Handler::WEBrick.shutdown
+    @server_thread.terminate
+  end
+
+  shared_examples 'an adapter' do
+    describe '#execute' do
+      it 'makes an actual HTTP request' do
+        response = adapter.execute(
+          document: Metaphysics::Artist.document, # TODO: We don't want adapter tests to depend on +Metaphysics::Artist+
+          operation_name: 'op',
+          variables: { id: 'yayoi-kusama' },
+          context: { user_id: 1 }
+        )
+
+        expect(response['data']['query']).to eq(Metaphysics::Artist.document.to_query_string)
+        expect(response['data']['variables']).to eq('id' => 'yayoi-kusama')
+        expect(response['data']['operationName']).to eq('op')
+        expect(response['errors']).to eq([])
+        expect(response['extensions']).to eq({})
+      end
+    end
+  end
+
+  describe Artemis::Adapters::NetHttpAdapter do
+    let(:adapter) { Artemis::Adapters::NetHttpAdapter.new('http://localhost:8000', service_name: nil, timeout: 5, pool_size: 5) }
+
+    it_behaves_like 'an adapter'
+  end
+end

--- a/spec/unit/adapters_spec.rb
+++ b/spec/unit/adapters_spec.rb
@@ -56,4 +56,10 @@ describe 'Adapters' do
 
     it_behaves_like 'an adapter'
   end
+
+  describe Artemis::Adapters::NetHttpAdapter do
+    let(:adapter) { Artemis::Adapters::NetHttpPersistentAdapter.new('http://localhost:8000', service_name: nil, timeout: 5, pool_size: 5) }
+
+    it_behaves_like 'an adapter'
+  end
 end


### PR DESCRIPTION
closes #7

The `net-http-persistent` gem manages persistent connections to increase the speed of HTTP. Artemis users now can switch to this adapter by changing the `:adapter` option in `config/graphql.yml` to `:net_http_persistent`.