### PR TITLE
Add an adapter for the curb gem

### DIFF
--- a/artemis.gemspec
+++ b/artemis.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "appraisal", "~> 2.2"
   spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "curb", "~> 0.9.6"
   spec.add_development_dependency "net-http-persistent", "~> 3.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.8"

--- a/lib/artemis/adapters.rb
+++ b/lib/artemis/adapters.rb
@@ -6,6 +6,7 @@ module Artemis
   module Adapters
     extend ActiveSupport::Autoload
 
+    autoload :CurbAdapter
     autoload :NetHttpAdapter
     autoload :NetHttpPersistentAdapter
     autoload :TestAdapter

--- a/lib/artemis/adapters/curb_adapter.rb
+++ b/lib/artemis/adapters/curb_adapter.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'delegate'
+
+require 'curb'
+
+module Artemis
+  module Adapters
+    class CurbAdapter < AbstractAdapter
+      attr_reader :multi
+
+      def initialize(uri, service_name: , timeout: , pool_size: )
+        super
+
+        @multi = Curl::Multi.new
+        @multi.pipeline = Curl::CURLPIPE_MULTIPLEX if defined?(Curl::CURLPIPE_MULTIPLEX)
+      end
+
+      def execute(document:, operation_name: nil, variables: {}, context: {})
+        easy = Curl::Easy.new(uri.to_s)
+
+        body = {}
+        body["query"] = document.to_query_string
+        body["variables"] = variables if variables.any?
+        body["operationName"] = operation_name if operation_name
+
+        easy.multi       = multi
+        easy.headers     = headers(context) || {}
+        easy.post_body   = JSON.generate(body)
+
+        if defined?(Curl::CURLPIPE_MULTIPLEX)
+          # This ensures libcurl waits for the connection to reveal if it is
+          # possible to pipeline/multiplex on before it continues.
+          easy.setopt(Curl::CURLOPT_PIPEWAIT, 1)
+          easy.version = Curl::HTTP_2_0
+        end
+
+        easy.http_post
+
+        if easy.response_code == 200 || easy.response_code == 400
+          JSON.parse(easy.body)
+        else
+          { "errors" => [{ "message" => "#{easy.response_code} #{easy.body}" }] }
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/adapters_spec.rb
+++ b/spec/unit/adapters_spec.rb
@@ -62,4 +62,10 @@ describe 'Adapters' do
 
     it_behaves_like 'an adapter'
   end
+
+  describe Artemis::Adapters::CurbAdapter do
+    let(:adapter) { Artemis::Adapters::CurbAdapter.new('http://localhost:8000', service_name: nil, timeout: 5, pool_size: 5) }
+
+    it_behaves_like 'an adapter'
+  end
 end

--- a/spec/unit/adapters_spec.rb
+++ b/spec/unit/adapters_spec.rb
@@ -57,7 +57,7 @@ describe 'Adapters' do
     it_behaves_like 'an adapter'
   end
 
-  describe Artemis::Adapters::NetHttpAdapter do
+  describe Artemis::Adapters::NetHttpPersistentAdapter do
     let(:adapter) { Artemis::Adapters::NetHttpPersistentAdapter.new('http://localhost:8000', service_name: nil, timeout: 5, pool_size: 5) }
 
     it_behaves_like 'an adapter'


### PR DESCRIPTION
As of writing [the `curb` gem](https://github.com/taf2/curb) is the only gem that exposes libcurl's HTTP/2 interface properly. Artemis users can now switch to this adapter by changing the `:adapter` option in `config/graphql.yml` to `:curb`.