### PR TITLE
Fix an issue where other gems' initializers are pushed to the post-finalization step

### DIFF
--- a/lib/artemis/railtie.rb
+++ b/lib/artemis/railtie.rb
@@ -28,7 +28,7 @@ module Artemis
       end
     end
 
-    initializer 'graphql.client.load_config', after: :eager_load! do |app|
+    initializer 'graphql.client.load_config' do |app|
       app.config_for(:graphql).each do |endpoint_name, options|
         Artemis::GraphQLEndpoint.register!(endpoint_name, options)
       end

--- a/test/railtie_test.rb
+++ b/test/railtie_test.rb
@@ -108,6 +108,10 @@ class RailtieTest < ActiveSupport::TestCase
 
     add_to_config <<-RUBY
       config.eager_load = true
+
+      initializer 'add_middleware' do |app|
+        app.config.middleware.use Rack::Head # Rack::Head is used just because it's almost always available
+      end
     RUBY
 
     boot_rails


### PR DESCRIPTION
The `after: :eager_load!` was causing `FrozenError: can't modify frozen Array` because it seemed to have pushed other gems' initializers to the post-finalization step on Rails boot.