### PR TITLE
Allow for setting up the test adapter without `url`

### DIFF
--- a/lib/artemis/adapters/abstract_adapter.rb
+++ b/lib/artemis/adapters/abstract_adapter.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support/core_ext/object/blank'
 require 'graphql/client/http'
 
 module Artemis
@@ -10,6 +11,8 @@ module Artemis
       EMPTY_HEADERS = {}.freeze
 
       def initialize(uri, service_name: , timeout: , pool_size: )
+        raise ArgumentError, "url is required (given `#{uri.inspect}')" if uri.blank?
+
         super(uri) # Do not pass in the block to avoid getting #headers and #connection overridden.
 
         @service_name = service_name.to_s

--- a/lib/artemis/graphql_endpoint.rb
+++ b/lib/artemis/graphql_endpoint.rb
@@ -38,7 +38,7 @@ module Artemis
 
     attr_reader :name, :url, :adapter, :timeout, :schema_path, :pool_size
 
-    def initialize(name, url: , adapter: :net_http, timeout: 10, schema_path: nil, pool_size: 25)
+    def initialize(name, url: nil, adapter: :net_http, timeout: 10, schema_path: nil, pool_size: 25)
       @name, @url, @adapter, @timeout, @schema_path, @pool_size = name.to_s, url, adapter, timeout, schema_path, pool_size
 
       @mutex_for_schema     = Mutex.new

--- a/spec/adapters_spec.rb
+++ b/spec/adapters_spec.rb
@@ -49,6 +49,14 @@ describe 'Adapters' do
   end
 
   shared_examples 'an adapter' do
+    describe '#initialize' do
+      it 'requires an url' do
+        expect do
+          adapter.class.new(nil, service_name: nil, timeout: 2, pool_size: 5)
+        end.to raise_error(ArgumentError, "url is required (given `nil')")
+      end
+    end
+
     describe '#execute' do
       it 'makes an actual HTTP request' do
         response = adapter.execute(

--- a/test/railtie_test.rb
+++ b/test/railtie_test.rb
@@ -36,7 +36,7 @@ class RailtieTest < ActiveSupport::TestCase
         development:
           metaphysics:
             url: https://metaphysics-production.artsy.net
-            adapter: :test
+            adapter: :curb
             timeout: 5
             pool_size: 25
       YAML
@@ -51,9 +51,27 @@ class RailtieTest < ActiveSupport::TestCase
 
     assert_equal GraphQL::Schema, endpoint.schema.class
     assert_equal "https://metaphysics-production.artsy.net", endpoint.url
-    assert_equal :test,     endpoint.adapter
+    assert_equal :curb,     endpoint.adapter
     assert_equal 5,         endpoint.timeout
     assert_equal 25,        endpoint.pool_size
+  end
+
+  test "test adapter does not require url" do
+    File.open("#{app_path}/config/graphql.yml", "w") do |f|
+      f.puts <<-YAML
+        development:
+          metaphysics:
+            adapter: :test
+      YAML
+    end
+
+    boot_rails
+
+    endpoint = Artemis::GraphQLEndpoint.lookup(:metaphysics)
+
+    assert_nil endpoint.url
+    assert_not_nil endpoint.connection
+    assert_equal :test, endpoint.adapter
   end
 
   test "adds a reloader that watches *.graphql files" do


### PR DESCRIPTION
When the `:test` adapter is chosen but the `url` key is missing the endpoint fails to register because of the missing `url`.

 * The `:test` adapter should be use-able without urls in `config/graphql.yml` so the test setup will be simpler
 * When using one of the rest of the adapters the `url` should be required