### PR TITLE
Keep persistent connections open for 30 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
  * Add a new entry here
+ * [#43](https://github.com/yuki24/artemis/pull/43): Keep persistent connections open for 30 minutes
  * [#42](https://github.com/yuki24/artemis/pull/42): Allow for setting up the test adapter without `url`
  * [#41](https://github.com/yuki24/artemis/pull/41): Add a mutation generator
  * [#40](https://github.com/yuki24/artemis/pull/40): Add a query generator

--- a/lib/artemis/adapters/net_http_persistent_adapter.rb
+++ b/lib/artemis/adapters/net_http_persistent_adapter.rb
@@ -2,6 +2,7 @@
 
 require 'delegate'
 
+require 'active_support/core_ext/numeric/time'
 require 'net/http/persistent'
 
 require 'artemis/adapters/net_http_adapter'
@@ -17,6 +18,7 @@ module Artemis
         @raw_connection = Net::HTTP::Persistent.new(name: service_name, pool_size: pool_size)
         @raw_connection.open_timeout = timeout
         @raw_connection.read_timeout = timeout
+        @raw_connection.idle_timeout = 30.minutes.to_i # TODO: Make it configurable
 
         @_connection = ConnectionWrapper.new(@raw_connection, uri)
       end


### PR DESCRIPTION
In one of Artsy's internal services, we've switched to the `:net_http_persistent` to speed up the communication with [our GraphQL service](https://github.com/artsy/metaphysics), but there wasn't a significant boost between before and after. This is because `Net::HTTP::Persistent`'s [default `idle_timeout` is set to 5 seconds](https://github.com/drbrain/net-http-persistent/blob/0e5a8fb8a27deff37247ddb3bc5e6c9e390face5/lib/net/http/persistent.rb#L517), which is very short. Short-lived connections make sense for browsers (usually very far from the server, has an unreliable network, downloads multiple resources from it), but I believe server-to-server connections can remain open indefinitely.

This PR changes the `idle_timeout` for 30 minutes, so the connection doesn't get reset unnecessarily frequently.