### PR TITLE
do not transform keys of query variables

### DIFF
--- a/lib/artemis/client.rb
+++ b/lib/artemis/client.rb
@@ -255,7 +255,7 @@ module Artemis
         def #{method_name}(context: {}, **arguments)
           client.query(
             self.class::#{const_name},
-            variables: arguments.deep_transform_keys {|key| key.to_s.camelize(:lower) },
+            variables: arguments,
             context: context
           )
         end


### PR DESCRIPTION
resolves #46 

This was a simple change but difficult to test- I made a new query with a snake-cased variable but it failed to construct the client due to not matching the Metaphysics schema. I could just make a tiny schema by hand or stub some internal method, but maybe it's not necessary to test this right now.

Also wondering: Where does `Client#compile_query_method!` get called? I can't find any reference to its code anywhere.