### PR TITLE
Attempt at extending callbacks to include before request / after request

### DIFF
--- a/artemis.gemspec
+++ b/artemis.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "railties", ">= 4.2.0"
 
   spec.add_development_dependency "appraisal", "~> 2.2"
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "curb", "~> 0.9.6"
   spec.add_development_dependency "net-http-persistent", "~> 3.0"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/artemis.gemspec
+++ b/artemis.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "railties", ">= 4.2.0"
 
   spec.add_development_dependency "appraisal", "~> 2.2"
-  spec.add_development_dependency "bundler", "~> 1.17"
+  spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "curb", "~> 0.9.6"
   spec.add_development_dependency "net-http-persistent", "~> 3.0"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/artemis/adapters/abstract_adapter.rb
+++ b/lib/artemis/adapters/abstract_adapter.rb
@@ -23,8 +23,8 @@ module Artemis
       # Public: Extension point for subclasses to set custom request headers.
       #
       # Returns Hash of String header names and values.
-      def headers(_context)
-        _context[:headers] || EMPTY_HEADERS
+      def headers(context)
+        context[:headers] || EMPTY_HEADERS
       end
 
       # Public: Make an HTTP request for GraphQL query.

--- a/lib/artemis/adapters/curb_adapter.rb
+++ b/lib/artemis/adapters/curb_adapter.rb
@@ -20,7 +20,7 @@ module Artemis
         @multi.pipeline = Curl::CURLPIPE_MULTIPLEX if defined?(Curl::CURLPIPE_MULTIPLEX)
       end
 
-      def execute(document:, operation_name: nil, variables: {}, callbacks:, context: {})
+      def execute(document:, operation_name: nil, variables: {}, callbacks: nil, context: {})
         easy = Curl::Easy.new(uri.to_s)
 
         body = {}
@@ -40,13 +40,13 @@ module Artemis
           easy.version = Curl::HTTP_2_0
         end
 
-        callbacks.before_request_callbacks.each do |callback|
+        Array(callbacks&.before_request_callbacks).each do |callback|
           callback.call(easy, easy.headers, easy.post_body, context)
         end
 
         easy.http_post
 
-        request_callbacks.after_request_callbacks.each do |callback|
+        Array(callbacks&.after_request_callbacks).each do |callback|
           callback.call(easy, easy.response_code, easy.body, context)
         end
 

--- a/lib/artemis/adapters/curb_adapter.rb
+++ b/lib/artemis/adapters/curb_adapter.rb
@@ -40,7 +40,7 @@ module Artemis
           easy.version = Curl::HTTP_2_0
         end
 
-        Array(callbacks&.before_request_callbacks).each do |callback|
+        callbacks&.before_request_callbacks&.each do |callback|
           callback.call(easy, easy.headers, easy.post_body, context)
         end
 

--- a/lib/artemis/adapters/curb_adapter.rb
+++ b/lib/artemis/adapters/curb_adapter.rb
@@ -20,7 +20,7 @@ module Artemis
         @multi.pipeline = Curl::CURLPIPE_MULTIPLEX if defined?(Curl::CURLPIPE_MULTIPLEX)
       end
 
-      def execute(document:, operation_name: nil, variables: {}, callbacks: nil, context: {})
+      def execute(document:, operation_name: nil, variables: {}, context: {})
         easy = Curl::Easy.new(uri.to_s)
 
         body = {}
@@ -40,13 +40,13 @@ module Artemis
           easy.version = Curl::HTTP_2_0
         end
 
-        callbacks&.before_request_callbacks&.each do |callback|
+        request_callbacks&.before_request_callbacks&.each do |callback|
           callback.call(easy, easy.headers, easy.post_body, context)
         end
 
         easy.http_post
 
-        Array(callbacks&.after_request_callbacks).each do |callback|
+        request_callbacks&.after_request_callbacks&.each do |callback|
           callback.call(easy, easy.response_code, easy.body, context)
         end
 

--- a/lib/artemis/adapters/net_http_adapter.rb
+++ b/lib/artemis/adapters/net_http_adapter.rb
@@ -10,7 +10,7 @@ module Artemis
   module Adapters
     class NetHttpAdapter < AbstractAdapter
       # Makes an HTTP request for GraphQL query.
-      def execute(document:, operation_name: nil, variables: {}, callbacks:, context: {})
+      def execute(document:, operation_name: nil, variables: {}, callbacks: nil, context: {})
         request = Net::HTTP::Post.new(uri.request_uri)
 
         request.basic_auth(uri.user, uri.password) if uri.user || uri.password
@@ -25,13 +25,13 @@ module Artemis
         body["operationName"] = operation_name if operation_name
         request.body = JSON.generate(body)
 
-        callbacks.before_request_callbacks.each do |callback|
+        Array(callbacks&.before_request_callbacks).each do |callback|
           callback.call(request, request.to_hash, request.body, context)
         end
 
         response = connection.request(request)
 
-        callbacks.after_request_callbacks.each do |callback|
+        Array(callbacks&.after_request_callbacks).each do |callback|
           callback.call(response, response.code.to_i, response.body, context)
         end
 

--- a/lib/artemis/adapters/net_http_adapter.rb
+++ b/lib/artemis/adapters/net_http_adapter.rb
@@ -10,7 +10,7 @@ module Artemis
   module Adapters
     class NetHttpAdapter < AbstractAdapter
       # Makes an HTTP request for GraphQL query.
-      def execute(document:, operation_name: nil, variables: {}, context: {})
+      def execute(document:, operation_name: nil, variables: {}, callbacks:, context: {})
         request = Net::HTTP::Post.new(uri.request_uri)
 
         request.basic_auth(uri.user, uri.password) if uri.user || uri.password
@@ -25,7 +25,15 @@ module Artemis
         body["operationName"] = operation_name if operation_name
         request.body = JSON.generate(body)
 
+        callbacks.before_request_callbacks.each do |callback|
+          callback.call(request, request.to_hash, request.body, context)
+        end
+
         response = connection.request(request)
+
+        callbacks.after_request_callbacks.each do |callback|
+          callback.call(response, response.code.to_i, response.body, context)
+        end
 
         case response.code.to_i
         when 200, 400

--- a/lib/artemis/adapters/net_http_adapter.rb
+++ b/lib/artemis/adapters/net_http_adapter.rb
@@ -25,13 +25,13 @@ module Artemis
         body["operationName"] = operation_name if operation_name
         request.body = JSON.generate(body)
 
-        Array(callbacks&.before_request_callbacks).each do |callback|
+        request_callbacks&.before_request_callbacks&.each do |callback|
           callback.call(request, request.to_hash, request.body, context)
         end
 
         response = connection.request(request)
 
-        Array(callbacks&.after_request_callbacks).each do |callback|
+        request_callbacks&.after_request_callbacks&.each do |callback|
           callback.call(response, response.code.to_i, response.body, context)
         end
 

--- a/lib/artemis/adapters/net_http_persistent_adapter.rb
+++ b/lib/artemis/adapters/net_http_persistent_adapter.rb
@@ -12,7 +12,7 @@ module Artemis
     class NetHttpPersistentAdapter < NetHttpAdapter
       attr_reader :_connection, :raw_connection
 
-      def initialize(uri, service_name: , timeout: , pool_size: )
+      def initialize(uri, service_name:, timeout:, pool_size:)
         super
 
         @raw_connection = Net::HTTP::Persistent.new(name: service_name, pool_size: pool_size)

--- a/lib/artemis/adapters/test_adapter.rb
+++ b/lib/artemis/adapters/test_adapter.rb
@@ -18,6 +18,14 @@ module Artemis
       def initialize(*)
       end
 
+      # Main entry point for an Adapter, it receives the callbacks, set them and clears them after
+      def call(document:, operation_name:, variables:, context: {}, callbacks: nil)
+        @request_callbacks = callbacks
+        result = execute(document: document, operation_name: operation_name, variables: variables, context: context)
+        @request_callbacks = nil
+        result
+      end
+
       def execute(**arguments)
         self.requests << Request.new(*arguments.values_at(:document, :operation_name, :variables, :context))
 

--- a/lib/artemis/client.rb
+++ b/lib/artemis/client.rb
@@ -146,7 +146,7 @@ module Artemis
       #   end
       #
       def before_execute(&block)
-        config.before_callbacks << block
+        config.before_execute_callbacks << block
       end
 
       # Defines a callback that will get called right after the
@@ -164,7 +164,7 @@ module Artemis
       #   end
       #
       def after_execute(&block)
-        config.after_callbacks << block
+        config.after_execute_callbacks << block
       end
 
       # Defines a callback that will get called right before making the
@@ -179,7 +179,7 @@ module Artemis
       #     ...
       #   end
       def before_request(&block)
-        config.before_request << block
+        config.before_request_callbacks << block
       end
 
       # Defines a callback that will get called right after making
@@ -195,7 +195,7 @@ module Artemis
       #   end
       #
       def after_request(&block)
-        config.after_request << block
+        config.after_request_callbacks << block
       end
 
       def resolve_graphql_file_path(filename, fragment: false)

--- a/lib/artemis/client.rb
+++ b/lib/artemis/client.rb
@@ -348,10 +348,10 @@ module Artemis
       end
 
       def execute(document:, operation_name: nil, variables: {}, context: {}) #:nodoc:
-        context = @default_context.deep_merge(context)
+        merged_context = @default_context.deep_merge(context)
 
         @callbacks.before_execute_callbacks.each do |callback|
-          callback.call(document, operation_name, variables, context)
+          callback.call(document, operation_name, variables, merged_context)
         end
 
         response = __getobj__.execute(
@@ -359,7 +359,7 @@ module Artemis
           operation_name: operation_name,
           variables: variables,
           callbacks: @callbacks,
-          context: context)
+          context: merged_context)
 
         @callbacks.after_execute_callbacks.each do |callback|
           callback.call(response['data'], response['errors'], response['extensions'])


### PR DESCRIPTION
From the ongoing discussion in #57 I took a small stab at it:

- Extend `Callbacks` to include `before_request` and `after_request` callbacks
- Pass the callbacks to the Executor so they can be passed in the execute

I didn't really find a better way to pass the callbacks to the adapters, this renders the `Executor` a bit useless. I think the code can be refactored a bit more (especially the adapter part) so execute is not that big of a method.

Didn't add specs yet, lets first see if this POC is in the right direction