### PR TITLE
Remove support for Rails 4.x because it doesn't work

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -13,40 +13,40 @@ appraise "rails_60" do
 end
 
 appraise "rails_52" do
-  gem "rails", '~> 5.2'
-  gem "railties", '~> 5.2'
-  gem "activesupport", '~> 5.2'
+  gem "rails", '~> 5.2.0'
+  gem "railties", '~> 5.2.0'
+  gem "activesupport", '~> 5.2.0'
 end
 
 appraise "rails_51" do
-  gem "rails", '~> 5.1'
-  gem "railties", '~> 5.1'
-  gem "activesupport", '~> 5.1'
+  gem "rails", '~> 5.1.0'
+  gem "railties", '~> 5.1.0'
+  gem "activesupport", '~> 5.1.0'
 end
 
 appraise "rails_50" do
-  gem "rails", '~> 5.0'
-  gem "railties", '~> 5.0'
-  gem "activesupport", '~> 5.0'
+  gem "rails", '~> 5.0.0'
+  gem "railties", '~> 5.0.0'
+  gem "activesupport", '~> 5.0.0'
 end
 
 appraise "rails_42" do
-  gem "rails", '~> 4.2'
-  gem "railties", '~> 4.2'
-  gem "activesupport", '~> 4.2'
+  gem "rails", '~> 4.2.0'
+  gem "railties", '~> 4.2.0'
+  gem "activesupport", '~> 4.2.0'
   gem "minitest", '5.10.3'
 end
 
 appraise "rails_41" do
-  gem "rails", '~> 4.1'
-  gem "railties", '~> 4.1'
-  gem "activesupport", '~> 4.1'
+  gem "rails", '~> 4.1.0'
+  gem "railties", '~> 4.1.0'
+  gem "activesupport", '~> 4.1.0'
   gem "minitest", '5.10.3'
 end
 
 appraise "rails_40" do
-  gem "rails", '~> 4.0'
-  gem "railties", '~> 4.0'
-  gem "activesupport", '~> 4.0'
+  gem "rails", '~> 4.0.0'
+  gem "railties", '~> 4.0.0'
+  gem "activesupport", '~> 4.0.0'
   gem "minitest", '5.10.3'
 end

--- a/gemfiles/rails_40.gemfile
+++ b/gemfiles/rails_40.gemfile
@@ -2,11 +2,11 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 4.0"
+gem "rails", "~> 4.0.0"
 gem "pry"
 gem "pry-byebug", platforms: :mri
-gem "railties", "~> 4.0"
-gem "activesupport", "~> 4.0"
+gem "railties", "~> 4.0.0"
+gem "activesupport", "~> 4.0.0"
 gem "minitest", "5.10.3"
 
 gemspec path: "../"

--- a/gemfiles/rails_41.gemfile
+++ b/gemfiles/rails_41.gemfile
@@ -2,11 +2,11 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 4.1"
+gem "rails", "~> 4.1.0"
 gem "pry"
 gem "pry-byebug", platforms: :mri
-gem "railties", "~> 4.1"
-gem "activesupport", "~> 4.1"
+gem "railties", "~> 4.1.0"
+gem "activesupport", "~> 4.1.0"
 gem "minitest", "5.10.3"
 
 gemspec path: "../"

--- a/gemfiles/rails_42.gemfile
+++ b/gemfiles/rails_42.gemfile
@@ -2,11 +2,11 @@
 
 source "https://rubygems.org"
 
+gem "rails", "~> 4.2.0"
 gem "pry"
 gem "pry-byebug", platforms: :mri
-gem "rails", "~> 4.2"
-gem "railties", "~> 4.2"
-gem "activesupport", "~> 4.2"
+gem "railties", "~> 4.2.0"
+gem "activesupport", "~> 4.2.0"
 gem "minitest", "5.10.3"
 
 gemspec path: "../"

--- a/gemfiles/rails_50.gemfile
+++ b/gemfiles/rails_50.gemfile
@@ -2,10 +2,10 @@
 
 source "https://rubygems.org"
 
+gem "rails", "~> 5.0.0"
 gem "pry"
 gem "pry-byebug", platforms: :mri
-gem "rails", "~> 5.0"
-gem "railties", "~> 5.0"
-gem "activesupport", "~> 5.0"
+gem "railties", "~> 5.0.0"
+gem "activesupport", "~> 5.0.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_51.gemfile
+++ b/gemfiles/rails_51.gemfile
@@ -2,10 +2,10 @@
 
 source "https://rubygems.org"
 
+gem "rails", "~> 5.1.0"
 gem "pry"
 gem "pry-byebug", platforms: :mri
-gem "rails", "~> 5.1"
-gem "railties", "~> 5.1"
-gem "activesupport", "~> 5.1"
+gem "railties", "~> 5.1.0"
+gem "activesupport", "~> 5.1.0"
 
 gemspec path: "../"

--- a/gemfiles/rails_52.gemfile
+++ b/gemfiles/rails_52.gemfile
@@ -2,10 +2,10 @@
 
 source "https://rubygems.org"
 
+gem "rails", "~> 5.2.0"
 gem "pry"
 gem "pry-byebug", platforms: :mri
-gem "rails", "~> 5.2"
-gem "railties", "~> 5.2"
-gem "activesupport", "~> 5.2"
+gem "railties", "~> 5.2.0"
+gem "activesupport", "~> 5.2.0"
 
 gemspec path: "../"


### PR DESCRIPTION
## What's up? 

Hey @yuki24 apologies, it's me again. Without any code change, I believe Artemis won't actually work with Rails 4.0.x. I was testing it with the app we have and realized the fluke. 

This PR aims to remove 4.0 support for now, but keep 4.1 support if tests pass. 

### How did the builds pass??? 
There is a fluke with the `Appraisals` file. 

```
appraise "rails_50" do
  gem "rails", '~> 5.0'
  gem "railties", '~> 5.0'
  gem "activesupport", '~> 5.0' # Bundler resolves this to 5.2.x 
end
```

When we used `~> 5.0`, it actually means `'>= 5.0', '< 6.0'`, which locks to Rails 5.2.x practically. 

![Screen Shot 2019-05-08 at 2 30 46 PM](https://user-images.githubusercontent.com/1251946/57398820-e6f30080-719d-11e9-8ffc-d90c750825b5.png)

https://depfu.com/blog/2016/12/14/get-to-know-your-twiddle-wakka

## What this PR does 
- Removed 4.0 support because there's a small number of places where things are broken  (Note: I'll make an attempt to fix that in a separate PR and leave it to you to decide if it's worth it)
- Tries to keep 4.1 support if tests pass 
- Adds the patch version for other Rails version in `Appraisals`