### PR TITLE
Avoid crashing when config/graphql.yml not exist

### DIFF
--- a/lib/artemis/railtie.rb
+++ b/lib/artemis/railtie.rb
@@ -57,8 +57,8 @@ module Artemis
 
     initializer 'graphql.client.preload', after: 'graphql.client.load_config' do |app|
       if app.config.eager_load && app.config.cache_classes
-        Artemis.config_for_graphql(app).keys.each do |endpoint_name|
-          endpoint_name.to_s.camelize.constantize.preload!
+        Artemis::GraphQLEndpoint.registered_services.each do |endpoint_name|
+          endpoint_name.camelize.constantize.preload!
         end
       end
     end

--- a/test/railtie_test.rb
+++ b/test/railtie_test.rb
@@ -195,6 +195,17 @@ class RailtieTest < ActiveSupport::TestCase
     assert defined?(Metaphysics::Artist), "Constant Metaphysics::Artist was not loaded"
   end
 
+  test "avoid crashing when eager_load is true but without config/graphql.yml" do
+    add_to_config <<-RUBY
+      config.cache_classes = true
+      config.eager_load = true
+    RUBY
+
+    assert_nothing_raised {
+      boot_rails
+    }
+  end
+
   private
 
   def app


### PR DESCRIPTION
Though #47 added a check for file existence, the app will still fail to boot if preload is enabled.
This PR addresses this issue and add a test case for this scenario.