### PR TITLE
Compare stub arguments and operation name separately in TestAdapter

### DIFF
--- a/lib/artemis/adapters/test_adapter.rb
+++ b/lib/artemis/adapters/test_adapter.rb
@@ -22,7 +22,7 @@ module Artemis
         self.requests << Request.new(*arguments.values_at(:document, :operation_name, :variables, :context))
 
         response = responses.detect do |mock|
-          arguments[:operation_name] == mock.operation_name && mock.arguments == :__unspecified__ || arguments[:variables] == mock.arguments
+          arguments[:operation_name] == mock.operation_name && (mock.arguments == :__unspecified__ || arguments[:variables] == mock.arguments)
         end
 
         response&.data || {

--- a/spec/test_helper_spec.rb
+++ b/spec/test_helper_spec.rb
@@ -70,6 +70,15 @@ describe Artemis::TestHelper do
     expect(yoshiki.data.artist.name).to eq("Artist Yoshiki")
   end
 
+  it "can mock separate GraphQL queries with the same arguments" do
+    stub_graphql("SpotifyClient", :artist, id: "yoshiki").to_return(:yoshiki)
+    stub_graphql(Metaphysics, :artist, id: "yoshiki").to_return(:yoshiki)
+
+    yoshiki = Metaphysics.artist(id: "yoshiki")
+    
+    expect(yoshiki.data.artist.name).to eq("Artist Yoshiki")
+  end
+
   it "allows to get raw fixture data as a Hash" do
     data = stub_graphql("SpotifyClient", :artist).get(:yoshiki)
 


### PR DESCRIPTION
With the existing code, the `TestAdapter` would return the wrong response if we used the same arguments for two different requests

By adding parentheses, we make sure requests using the same arguments are returned correctly. 