### PR TITLE
Allow overriding all headers in the Artemis rake task

### DIFF
--- a/lib/tasks/artemis.rake
+++ b/lib/tasks/artemis.rake
@@ -22,6 +22,7 @@ namespace :graphql do
                 end
 
       headers          = ENV['AUTHORIZATION'] ? { Authorization: ENV['AUTHORIZATION'] } : {}
+      headers          = JSON.parse(ENV["ARTEMIS_HEADERS"]) if ENV["ARTEMIS_HEADERS"].present?
       service_class    = service.to_s.camelize.constantize
       schema_path      = service_class.endpoint.schema_path
       schema           = service_class.connection


### PR DESCRIPTION
For some clients I use, I need a different auth header, this allows me to do that by using an ENV variable of "ARTEMIS_HEADERS" that allows me to set a JSON String for the headers. Not the greatest solution, but it works!