### PR TITLE
Ability to use YAML aliases in test fixtures

### DIFF
--- a/lib/artemis/test_helper.rb
+++ b/lib/artemis/test_helper.rb
@@ -70,7 +70,7 @@ module Artemis
     end
 
     def read_erb_yaml(path) #:nodoc:
-      YAML.load(ERB.new(File.read(path)).result)
+      YAML.load(ERB.new(File.read(path)).result, aliases: true)
     end
 
     class StubbingDSL #:nodoc:


### PR DESCRIPTION
Ive found it helpful to enable aliases in our YAML fixtures.
Simplified example:
```yaml
customer: &customer
  id: gid://shopify/Customer/123456789
  firstName: Arthur
  lastName: Cheek

line_item: &line_item
  id: gid://shopify/LineItem/123456789
  quantity: 1
  customAttributes: {}

custom_line_item: &custom_line_item
  <<: *line_item
  customAttributes:
    custom: true

order: &order
  customer: *customer
  lineItems:
    nodes:
      - *line_item

multiple_custom_line_items:
  <<: *order
  lineItems:
    nodes:
      - quantity: 10
        <<: *custom_line_item

no_line_items:
  <<: *order
  lineItems:
    nodes: []
```

